### PR TITLE
Updates create and repeat test run execution to match backend changes

### DIFF
--- a/src/app/components/test/test-details/test-details.component.ts
+++ b/src/app/components/test/test-details/test-details.component.ts
@@ -112,9 +112,13 @@ export class TestDetailsComponent {
             }
           }
         }
-        const testConfig: any = await this.testSandbox.createTestRunConfig(this.selectedDataFinal);
-        this.testSandbox.createTestRunExecution(this.callbackForStartTestExecution.bind(this),
-          testConfig.id, this.testName, this.testRunAPI.getSelectedOperator().id, this.description);
+        this.testSandbox.createTestRunExecution(
+          this.callbackForStartTestExecution.bind(this),
+          this.selectedDataFinal,
+          this.testName,
+          this.testRunAPI.getSelectedOperator().id,
+          this.description
+        );
       }
     }
   }

--- a/src/app/components/test/test-execution-history/test-execution-history.component.ts
+++ b/src/app/components/test/test-execution-history/test-execution-history.component.ts
@@ -229,8 +229,7 @@ export class TestExecutionHistoryComponent {
       const title: any = executionData.title.slice(0, executionData.title.length - 20);
       this.sharedAPI.setAppState(APP_STATE[1]);
       this.sharedAPI.setWebSocketLoader(true);
-      this.testSandbox.createTestRunExecution(this.repeatExecution.bind(this), executionData.test_run_config_id,
-        title, executionData.operator.id, executionData.description);
+      this.testSandbox.repeatTestRunExecution(this.repeatExecution.bind(this), executionData.id);
     }
   }
   repeatExecution(execId: any) {

--- a/src/app/components/test/test.sandbox.ts
+++ b/src/app/components/test/test.sandbox.ts
@@ -135,15 +135,14 @@ export class TestSandbox {
   setDefaultSelectedData(selectedData: any) {
     this.testRunStore.setSelectedTestCase(selectedData);
   }
-  // Trigger core_apis function to create new test-run-config
-  async createTestRunConfig(requestJson: any) {
-    const testConfigData = await this.testRunAPI.createTestRunConfig(requestJson);
-    return testConfigData;
-  }
   // Trigger core_apis function to create new test-run-executions
-  createTestRunExecution(callback: any, testConfigId: number, testName: string, operatorId: any, description: any) {
+  createTestRunExecution(callback: any, selectedDataFinal: any, testName: string, operatorId: any, description: any) {
     const selectedProjectId = this.sharedAPI.getSelectedProjectType().id;
-    this.testRunAPI.createTestRunExecution(callback, testConfigId, selectedProjectId, testName, operatorId, description);
+    this.testRunAPI.createTestRunExecution(callback, selectedDataFinal, selectedProjectId, testName, operatorId, description);
+  }
+  // Trigger core_apis function to repeat test-run-executions
+  repeatTestRunExecution(callback: any, testExecutionId: number) {
+    this.testRunAPI.repeatTestRunExecution(callback, testExecutionId);
   }
   // Start test execution and set initial running testcase data
   setRunningTestsDataOnStart(execId: any) {

--- a/src/app/shared/core_apis/test-run.ts
+++ b/src/app/shared/core_apis/test-run.ts
@@ -243,15 +243,20 @@ export class TestRunAPI {
     );
   }
 
-  // Create new test run config
-  async createTestRunConfig(requestJson: any) {
-    const testConfigData = await this.testRunService.createTestRunConfig(requestJson);
-    return testConfigData;
+  // Create new test run execution
+  createTestRunExecution(callback: any, selectedDataFinal: any, selectedProjectId: number, testName: string, operatorId: any, description: any) {
+    return this.testRunService.createTestRunExecution(selectedDataFinal, selectedProjectId, testName, operatorId, description).subscribe(
+      (data) => {
+        callback(data.id);
+        return data;
+      }, err => {
+        this.sharedService.showPopUp();
+      });
   }
 
-  // Create new test run execution
-  createTestRunExecution(callback: any, testConfigId: number, selectedProjectId: number, testName: string, operatorId: any, description: any) {
-    return this.testRunService.createTestRunExecution(testConfigId, selectedProjectId, testName, operatorId, description).subscribe(
+  // Repeats a test run execution
+  repeatTestRunExecution(callback: any, testExecutionId: number) {
+    return this.testRunService.repeatTestRunExecution(testExecutionId).subscribe(
       (data) => {
         callback(data.id);
         return data;

--- a/src/app/shared/test-run-utils.ts
+++ b/src/app/shared/test-run-utils.ts
@@ -37,22 +37,25 @@ export class TestRunService {
   getDefaultTestCases(): Observable<any> {
     return this.http.get(getBaseUrl() + 'test_collections');
   }
-  async createTestRunConfig(requestJson: any) {
-    const testConfigData = await this.http.post(getBaseUrl() + 'test_run_configs', requestJson).toPromise();
-    return testConfigData;
-  }
-  createTestRunExecution(testConfigId: number, selectedProjectId: number, testName: string, operatorId: any,
+  createTestRunExecution(selectedDataFinal: any, selectedProjectId: number, testName: string, operatorId: any,
     description: any): Observable<any> {
     /* eslint-disable @typescript-eslint/naming-convention */
+    const selected_tests = selectedDataFinal.selected_tests;
     const requestJson = {
       'test_run_execution_in':
       {
-        'title': testName + '_' + getTimeStamp(), 'test_run_config_id': testConfigId,
-        'project_id': selectedProjectId, 'description': description, 'operator_id': operatorId
-      }
+        'title': testName + '_' + getTimeStamp(),
+        'project_id': selectedProjectId,
+        'description': description,
+        'operator_id': operatorId
+      },
+      selected_tests
     };
     /* eslint-enable @typescript-eslint/naming-convention */
     return this.http.post(getBaseUrl() + 'test_run_executions', requestJson);
+  }
+  repeatTestRunExecution(testExecutionId: number): Observable<any> {
+    return this.http.post(getBaseUrl() + `test_run_executions/${testExecutionId}/repeat`, {});
   }
   startTestRunExecution(id: number): Observable<any> {
     return this.http.post(getBaseUrl() + 'test_run_executions/' + id + '/start', {});


### PR DESCRIPTION
**Issue**: [Remove TestRunConfig #14](https://github.com/project-chip/certification-tool/issues/14)
**Backend PR counterpart**: [[Fix] remove TestRunConfig usage from TH Backend (#581) #6](https://github.com/project-chip/certification-tool-backend/pull/6)

- Updates create test run to swap test_run_config_id with selected_tests

- Updates repeat test run execution to use new repeat end point

- Removes test run config API calls