### PR TITLE
Fix 356: Adds CSS to make TH python test logs respect line breaks

### DIFF
--- a/src/app/components/test/test-execution/test-logs/test-log-console/test-log-console.component.scss
+++ b/src/app/components/test/test-execution/test-logs/test-log-console/test-log-console.component.scss
@@ -29,6 +29,7 @@
   td {
     border: none !important;
     padding: 2px !important;
+    white-space: break-spaces;
   }
   tr {
     background: #212121;;


### PR DESCRIPTION
Adds CSS to make TH python test logs respect line breaks
Addresses: https://github.com/project-chip/certification-tool/issues/356


![image](https://github.com/user-attachments/assets/7fbe8070-92c8-461e-b488-b3bf742fcee1)
