### PR TITLE
[Camera] Fix frontend Dockerfile to ensure patch-package applies patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN bash -c "if [ $INSTALL_PUPPETEER == 'true' ] ; then apt-get update && apt-ge
 WORKDIR /app
 RUN bash -c "if [ $INSTALL_PUPPETEER == 'true' ] ; then npm install puppeteer ; fi"
 COPY package*.json /app/
+COPY patches /app/patches
 # The application resides in the root directory (/app). By default, npm restricts
 # lifecycle scripts (e.g., postinstall) from executing with elevated privileges.
 # To ensure patch-package applies the patch, the --unsafe-perm flag is used here.


### PR DESCRIPTION
This PR fixes below error seen when running angular app:
```
Error: src/app/components/shared/popup-modal/popup-modal.component.ts:24:19 - error TS2306: File '/app/node_modules/shaka-player/dist/shaka-player.compiled.d.ts' is not a module.
[0] 
[0] 24 import shaka from 'shaka-player/dist/shaka-player.compiled';
```
The error was seen because the patches directory was not available within the Docker's Working Directory during package installation while building image. The patches directory is being copied after the package installation.
This change ensures the patches directory is available prior to node packages being installed so that npm is able to find the patch and apply.