### PR TITLE
TH-UI - Fix test run list toggling and reordering on clicks and during execution

### DIFF
--- a/src/app/components/test/test-execution-history/test-execution-history.component.spec.ts
+++ b/src/app/components/test/test-execution-history/test-execution-history.component.spec.ts
@@ -23,6 +23,7 @@ import { DialogService } from 'primeng/dynamicdialog';
 import { SharedAPI } from 'src/app/shared/core_apis/shared';
 import { SharedService } from 'src/app/shared/core_apis/shared-utils';
 import { TestRunAPI } from 'src/app/shared/core_apis/test-run';
+import { MainAreaSandbox } from 'src/app/components/main-area/main-area.sandbox';
 import { TestSandbox } from '../test.sandbox';
 import { TestExecutionHistoryComponent } from './test-execution-history.component';
 
@@ -45,12 +46,17 @@ class MockSharedAPI {
     return { id: 1 };
   };
   setIsProjectTypeSelected() { }
+  setCertificationMode() { }
+}
+class MockMainAreaSandbox {
+  isTestPanel = true;
+  isUtilityPanel = false;
 }
 class MockDialogService { }
 class MockTestRunAPI { }
 class MockSharedService { }
 describe('TestExecutionHistoryComponent', () => {
-  let component: TestExecutionHistoryComponent, testSandbox,
+  let component: TestExecutionHistoryComponent, testSandbox: TestSandbox,
     domSanitizer, sharedAPI, dialogService, testRunAPI;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -61,7 +67,8 @@ describe('TestExecutionHistoryComponent', () => {
         { provide: SharedAPI, useClass: MockSharedAPI },
         { provide: DialogService, useClass: MockDialogService },
         { provide: TestRunAPI, useClass: MockTestRunAPI },
-        { provide: SharedService, useClass: MockSharedService }
+        { provide: SharedService, useClass: MockSharedService },
+        { provide: MainAreaSandbox, useClass: MockMainAreaSandbox }
       ]
     }).compileComponents();
     component = TestBed.inject(TestExecutionHistoryComponent);
@@ -76,6 +83,13 @@ describe('TestExecutionHistoryComponent', () => {
   });
   it('it should match return', () => {
     expect(component.filterProjectId()).toEqual(testExecutionHistory.reverse());
+  });
+  it('should keep a stable order across calls without mutating the stored results', () => {
+    const storedOrder = testSandbox.getTestExecutionResult().map((run: any) => run.id);
+    const firstCall = component.filterProjectId().map((run: any) => run.id);
+    const secondCall = component.filterProjectId().map((run: any) => run.id);
+    expect(secondCall).toEqual(firstCall);
+    expect(testSandbox.getTestExecutionResult().map((run: any) => run.id)).toEqual(storedOrder);
   });
 });
 

--- a/src/app/components/test/test-execution-history/test-execution-history.component.ts
+++ b/src/app/components/test/test-execution-history/test-execution-history.component.ts
@@ -82,7 +82,9 @@ export class TestExecutionHistoryComponent {
 
     if (filterData.length) {
       this.sharedAPI.setIsProjectTypeSelected(1);
-      return filterData.reverse();
+      // slice() prevents reverse() from mutating the stored array and the UI
+      // from flipping the displayed order (#1086).
+      return filterData.slice().reverse();
     } else {
       if (this.isSearch === false && this.testSandbox.getTestExecutionResult().length === 0 &&
         this.testSandbox.getArchivedTestResult().length === 0) {


### PR DESCRIPTION
#### Summary

Fixes an issue where the test run list in the TH-UI continuously toggled between its first and last entries and showed them in reverse order when clicking anywhere in the UI or while a test run was executing (the list rendering reversed the stored run array in place on every Angular change detection cycle), by reversing a copy of the array so the stored order is never modified.

#### Included in this PR

- Reverse a copy of the stored test run list for display instead of reversing it in place (`test-execution-history.component.ts`)
- Add a regression test verifying the list keeps a stable order across calls without mutating the stored results (`test-execution-history.component.spec.ts`)
- Add the missing `MainAreaSandbox` and `setCertificationMode` mocks the component spec needed to run at all (`test-execution-history.component.spec.ts`)

#### Testing

Unit tests (the regression test fails against the previous code and passes with the fix):

```
npx ng test --watch=false \
    --browsers=ChromeHeadlessPuppeteer \
    --include='**/test-execution-history/*.spec.ts'
```

#### Related issues

Fixes project-chip/certification-tool#1086
